### PR TITLE
Bugfix/geth deterministic errors

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -39,6 +39,7 @@ var GETH_DETERMINISTIC_ERRORS = []string{
 	"invalid jump destination",
 	"invalid opcode",
 	"stack limit reached 1024",
+	"stack underflow (",
 }
 
 const PARITY_BAD_INSTRUCTION_FE = "Bad instruction fe"

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -40,6 +40,7 @@ var GETH_DETERMINISTIC_ERRORS = []string{
 	"invalid opcode",
 	"stack limit reached 1024",
 	"stack underflow (",
+	"gas uint64 overflow",
 }
 
 const PARITY_BAD_INSTRUCTION_FE = "Bad instruction fe"


### PR DESCRIPTION
Add 2 geth deterministic errors which we caught when running substreams:
- stack underflow
- gas uint64 overflow