### PR TITLE
Categorize StackUnderflow Reth error as deterministic

### DIFF
--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -63,6 +63,7 @@ var RETH_DETERMINISTIC_ERRORS = []string{
 	"invalidjump",
 	"opcodenotfound",
 	"stackoverflow",
+	"stackunderflow",
 	"outofgas",
 	"invalidfeopcode",
 }


### PR DESCRIPTION
Substreams tier1/2 keeps retrying on that error:

```
2026-05-27T15:43:13.790Z WARN (rpc) retrying RPCCall on non-deterministic RPC call error {"trace_id": "1", "error": "rpc error (code -32003): EVM error: StackUnderflow", "at_block": "7fe17e72c0412fb100795cfc9de4567949755e085c635354ee3d873a758cff1d", "endpoint": "<redacted>"}
```


And eventually fails:
```
2026-05-27T16:30:40.944Z ERRO (substreams-tier1) finished streaming call with code Internal {"grpc.start_time": "2026-05-27T16:25:06Z", "system": "grpc", "span.kind": "server", "grpc.service": "sf.substreams.rpc.v3.Stream", "grpc.method": "Blocks", "peer.address": "[fd00:8080:20:2::1006]:49707", "error": "error during init_stores_and_backprocess: run_parallel_process failed: parallel processing run: scheduler run: segment [35129000-35130000] failed while streaming data: receiving stream resp: rpc error: code = Internal desc = stream terminated by RST_STREAM with error code: INTERNAL_ERROR", "grpc.code": "Internal", "grpc.time_ms": 334299.96875}
```

This PR should fix this.