### PR TITLE
fix: -32602 state-unavailable errors no longer classified deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 - **Breaking** `eth.NewAddress` is now strict in argument it accepts, the received input must have exactly 20 bytes once decoded. You can find back the previous behavior by using `NewAddressLoose` that has been added.
 
-- JSON-RPC code `-32602` is now treated as a deterministic error.
+- JSON-RPC code `-32602` is now treated as a deterministic error, except when the message indicates state/block unavailability (see `NON_DETERMINISTIC_STATE_MESSAGES` in the Fixed section).
 
 - **Breaking** The `ABI` has changed so that multiple events/functions of the name or same id are parsed correctly, in order defined.
 
@@ -23,6 +23,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 - _Deprecated_ `ABI#FindFunction` replaced with `ABI#FindFunctionByHash`.
 
 ### Fixed
+
+- Fixed `rpc.IsGenericDeterministicError` (and thus `rpc.IsDeterministicError`) misclassifying `-32602` state/block unavailability errors (e.g. `Block requested not found ... historical state that is not available`, `missing trie node`) as deterministic. These are transient, node-capability dependent conditions (pruned node) that an archive node answers correctly, so they must not be cached permanently. A new `rpc.NON_DETERMINISTIC_STATE_MESSAGES` list excludes them.
 
 - Fixed `Uint256.MarshalText()` to return hex-encoded strings (e.g., `0x1234...`) instead of decimal strings, matching Ethereum conventions and the behavior of `MarshalJSONRPC()`.
 

--- a/rpc/errors.go
+++ b/rpc/errors.go
@@ -44,6 +44,19 @@ func (e *ErrResponse) Error() string {
 const JSON_RPC_INVALID_REQUEST_ERROR = -32600
 const JSON_RPC_INVALID_ARGUMENT_ERROR = -32602
 
+// NON_DETERMINISTIC_STATE_MESSAGES holds (lower-cased) substrings that some nodes
+// report under the generic `-32602`/`-32600` codes but which are actually transient,
+// node-capability dependent conditions rather than a property of the call itself. A
+// pruned node returns these for state/blocks it no longer holds, while an archive node
+// (or the same node at a different time) answers the exact same call correctly. They
+// must therefore NOT be treated as deterministic, otherwise consumers caching on the
+// error would poison the entry permanently.
+var NON_DETERMINISTIC_STATE_MESSAGES = []string{
+	"state is not available",
+	"historical state that is not available",
+	"missing trie node",
+}
+
 var GETH_DETERMINISTIC_ERRORS = []string{
 	"revert",
 	"invalid jump destination",
@@ -99,7 +112,21 @@ func IsDeterministicError(err *ErrResponse) bool {
 }
 
 func IsGenericDeterministicError(err *ErrResponse) bool {
-	return err.Code == JSON_RPC_INVALID_ARGUMENT_ERROR || err.Code == JSON_RPC_INVALID_REQUEST_ERROR
+	if err.Code != JSON_RPC_INVALID_ARGUMENT_ERROR && err.Code != JSON_RPC_INVALID_REQUEST_ERROR {
+		return false
+	}
+
+	// Some nodes reuse the generic `-32602`/`-32600` codes for state/block unavailability,
+	// which is a node-state condition (pruned data) and not a property of the call. Exclude
+	// those so they are not permanently cached as deterministic by consumers.
+	msg := strings.ToLower(err.Message)
+	for _, stateMsg := range NON_DETERMINISTIC_STATE_MESSAGES {
+		if strings.Contains(msg, stateMsg) {
+			return false
+		}
+	}
+
+	return true
 }
 
 func IsGethDeterministicError(err *ErrResponse) bool {

--- a/rpc/errors_test.go
+++ b/rpc/errors_test.go
@@ -37,6 +37,24 @@ func TestIsDeterministicError(t *testing.T) {
 			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "Invalid argument"},
 			expected: true,
 		},
+		// -32602 with state/block unavailability messages must NOT be deterministic
+		{
+			// Exact error observed in production from Monad RPC. It is transient/node-state
+			// dependent (pruned node), so it must never be cached as deterministic.
+			name:     "invalid argument block requested not found (historical state)",
+			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "Block requested not found. Request might be querying historical state that is not available. If possible, reformulate query to point to more recent blocks"},
+			expected: false,
+		},
+		{
+			name:     "invalid argument state is not available",
+			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "state is not available for block 0x1234"},
+			expected: false,
+		},
+		{
+			name:     "invalid argument missing trie node",
+			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "missing trie node 0xabc (path ) state 0xdef is not available"},
+			expected: false,
+		},
 		// Geth deterministic errors
 		{
 			name:     "geth revert error",
@@ -170,6 +188,32 @@ func TestIsGenericDeterministicError(t *testing.T) {
 		{
 			name:     "invalid argument error",
 			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "Invalid argument"},
+			expected: true,
+		},
+		{
+			name:     "invalid argument revert still deterministic",
+			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "execution reverted"},
+			expected: true,
+		},
+		{
+			// Exact error observed in production from Monad RPC.
+			name:     "invalid argument block requested not found is not deterministic",
+			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "Block requested not found. Request might be querying historical state that is not available. If possible, reformulate query to point to more recent blocks"},
+			expected: false,
+		},
+		{
+			name:     "invalid argument state is not available is not deterministic",
+			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "state is not available for block 0x1234"},
+			expected: false,
+		},
+		{
+			name:     "invalid argument missing trie node is not deterministic",
+			err:      &ErrResponse{Code: JSON_RPC_INVALID_ARGUMENT_ERROR, Message: "missing trie node 0xabc"},
+			expected: false,
+		},
+		{
+			name:     "invalid request unaffected by state guard",
+			err:      &ErrResponse{Code: JSON_RPC_INVALID_REQUEST_ERROR, Message: "Invalid request"},
 			expected: true,
 		},
 		{


### PR DESCRIPTION
## Problem

`rpc.IsGenericDeterministicError` trusted the JSON-RPC error code alone: any `-32602` (`JSON_RPC_INVALID_ARGUMENT_ERROR`) or `-32600` (`JSON_RPC_INVALID_REQUEST_ERROR`) was classified deterministic.

Some nodes reuse `-32602` for **state/block unavailability** (pruned node). This is transient and node-capability dependent — an archive node, or the same node at a different time, answers the exact same call correctly. Downstream consumers (e.g. `evmx`) cache deterministic errors **permanently**, so such an error poisons the `(block, to, data)` cache key forever.

Exact error observed in production on Monad RPC:

```
rpc error (code -32602): Block requested not found. Request might be querying historical state that is not available. If possible, reformulate query to point to more recent blocks
```

## Fix

Add a `NON_DETERMINISTIC_STATE_MESSAGES` guard (case-insensitive substring match) checked before returning `true` from `IsGenericDeterministicError`:

- `state is not available`
- `historical state that is not available`
- `missing trie node`

`-32602`/`-32600` with revert or other genuine argument errors stay deterministic. The geth/reth/parity/ganache message-based functions are untouched.

## Tests

Table-driven cases added to `TestIsDeterministicError` and `TestIsGenericDeterministicError`:

- `-32602` with state-unavailable messages (incl. the exact Monad production string) → `false`
- `-32602` with revert / plain "Invalid argument" → still `true`
- `-32600` unaffected
- real geth/reth/parity/ganache messages → still `true`

All `./rpc/` tests pass.

## Changelog

`### Fixed` entry added; the existing `### Changed` `-32602` note clarified with the exception.