### PR TITLE
ci: add Test workflow pulling Go version from go.mod

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,25 @@
+name: "Test"
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout Repository"
+        uses: actions/checkout@v4
+
+      - name: "Setup Go"
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: "Run Tests"
+        run: go test ./...


### PR DESCRIPTION
## Summary

Adds a GitHub Actions **Test** workflow so branch protection's required test check can pass for eth-go.

- Runs the full suite (`go test ./...`) on pushes to `master` and on pull requests.
- Reads the Go version from `go.mod` via `setup-go`'s `go-version-file`, avoiding hardcoded version drift.

## Notes

Branch protection's required status check must point at the job named **test** to unblock merges.

## Verification

`go test ./...` passes locally across all packages.